### PR TITLE
Fix/body margin

### DIFF
--- a/core/src/lib/shell/shell.component.html
+++ b/core/src/lib/shell/shell.component.html
@@ -31,6 +31,7 @@
 <div class="garuda-shell-content" [class.garuda-shell-relative]="relativePosition()">
   <ng-content></ng-content>
 </div>
+
 <p-toast position="top-left" key="top-left" />
 <p-toast position="top-center" key="top-center" />
 <p-toast position="top-right" key="top-right" />
@@ -38,3 +39,5 @@
 <p-toast position="bottom-center" key="bottom-center" />
 <p-toast position="bottom-right" key="bottom-right" />
 <p-toast position="center" key="center" />
+
+<p-scroll-top [buttonProps]="{ styleClass: 'z-50', rounded: true }"></p-scroll-top>

--- a/core/src/lib/shell/shell.component.scss
+++ b/core/src/lib/shell/shell.component.scss
@@ -6,10 +6,10 @@
   --p-menubar-background: rgb(from var(--bg-color) r g b / 0.2);
   backdrop-filter: blur(5px);
   border-radius: var(--p-menubar-border-radius);
+  margin: 8px;
 }
 
 .garuda-shell-menubar:not(.garuda-shell-relative) {
-  position: fixed;
   width: calc(100% - 16px);
   z-index: 1000;
 }
@@ -21,6 +21,11 @@
 .garuda-shell__dropdown {
   --p-menu-background: rgb(from var(--bg-color) r g b / 0.2);
   backdrop-filter: blur(5px);
+  margin: 8px;
+}
+
+.garuda-shell-content {
+  padding: 8px;
 }
 
 .garuda-shell__dropdown.garuda-shell-relative {

--- a/core/src/lib/shell/shell.component.ts
+++ b/core/src/lib/shell/shell.component.ts
@@ -18,12 +18,13 @@ import { Toast } from 'primeng/toast';
 import { Button } from 'primeng/button';
 import { ShellBarDropdownToggleDirective } from './directives/shell-bar-dropdown-toggle.directive';
 import { Menu } from 'primeng/menu';
+import { ScrollTop } from 'primeng/scrolltop';
 
 const MENU_TOGGLE_GLOBAL_STYLE_ID = 'garuda-ng__menu-toggle-style';
 
 @Component({
   selector: 'garuda-shell',
-  imports: [Menubar, Toast, Button, Menu],
+  imports: [Menubar, Toast, Button, Menu, ScrollTop],
   templateUrl: './shell.component.html',
   styleUrl: './shell.component.scss',
   host: {

--- a/docs/src/styles.scss
+++ b/docs/src/styles.scss
@@ -2,6 +2,10 @@
 @import 'primeicons/primeicons.css';
 @import 'highlight.js/styles/github-dark.css';
 
+body {
+  margin: 0;
+}
+
 .component-docs {
   margin: 0 8px;
 }


### PR DESCRIPTION
Fixes the page layout shift on Angular page transitions.

Weirdly enough, the margin gets set automatically on the docs page. All other websites consuming this library so far do not have it, however.