### PR TITLE
feat(shell): content-padding property of shell

### DIFF
--- a/core/src/lib/shell/shell.component.scss
+++ b/core/src/lib/shell/shell.component.scss
@@ -15,7 +15,7 @@
 }
 
 .garuda-shell-content:not(.garuda-shell-relative) {
-  padding-top: 60px;
+  padding-top: var(--content-padding);
 }
 
 .garuda-shell__dropdown {

--- a/core/src/lib/shell/shell.component.ts
+++ b/core/src/lib/shell/shell.component.ts
@@ -27,7 +27,8 @@ const MENU_TOGGLE_GLOBAL_STYLE_ID = 'garuda-ng__menu-toggle-style';
   templateUrl: './shell.component.html',
   styleUrl: './shell.component.scss',
   host: {
-    class: 'garuda-shell',
+    'class': 'garuda-shell',
+    '[style.--content-padding.px]': 'contentPadding()',
   },
 })
 export class ShellComponent implements OnInit, OnDestroy {
@@ -36,11 +37,14 @@ export class ShellComponent implements OnInit, OnDestroy {
   menuItems = input<MenuItem[]>([]);
   relativePosition = input<boolean>(false);
   alwaysShowDropdownMenu = input<boolean>(false);
+  contentPadding = input<number>(60);
 
   dropdownOpen = signal<boolean>(false);
 
   dropdownButton = contentChild(ShellBarDropdownToggleDirective);
-  dropdownButtonRef = contentChild(ShellBarDropdownToggleDirective, { read: ElementRef });
+  dropdownButtonRef = contentChild(ShellBarDropdownToggleDirective, {
+    read: ElementRef,
+  });
   autoDropdownButtonRef = viewChild('autoDropdownButton', { read: ElementRef });
   menu = viewChild.required('menu', { read: ElementRef });
 

--- a/docs/src/app/components/shell/shell.component.html
+++ b/docs/src/app/components/shell/shell.component.html
@@ -98,6 +98,18 @@
   </section>
 
   <section class="docs-section">
+    <h2>Content Padding</h2>
+
+    <p>
+      The
+      <code
+        >[content-padding] property may be used to adjust the top padding of the content inside of the shell. Value is interpreted as pixels
+        (px), defaults to 60.</code
+      >
+    </p>
+  </section>
+
+  <section class="docs-section">
     <h2>Relative Position</h2>
 
     <p>


### PR DESCRIPTION
Added a new content-padding property to shell which allows for a custom top-padding of the content of garuda-shell. This is useful for projects with a custom body margin/padding.